### PR TITLE
Title: feat: add accounting period year (period_year) across transactions, reports, prognosis, and dashboard

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: "Buggrapport"
+about: "Hjälp oss hitta och fixa en bugg"
+title: "bug: "
+labels: ["bug"]
+assignees: []
+---
+
+## Sammanfattning
+Kort beskrivning av buggen.
+
+## Steg för att återskapa
+1. Gå till ...
+2. Klicka på ...
+3. Fyll i ...
+4. Fel uppstår: ...
+
+## Förväntat beteende
+Vad du förväntade dig skulle hända.
+
+## Faktiskt beteende
+Vad som hände istället (inkl. felmeddelanden).
+
+## Skärmdumpar / Loggar
+Länka bilder eller klistra in relevanta loggar (maskera ev. känslig info).
+
+## Miljö
+- OS: [t.ex. Windows 11]
+- Browser/klient: [t.ex. Edge/Chrome, version]
+- Appversion/commit: [t.ex. v0.7.0 / commit-hash]
+- Databas: [t.ex. SQL Server version]
+
+## Extra info
+Övriga detaljer som kan hjälpa felsökning.
+
+## Checklista
+- [ ] Kan reproduceras konsekvent
+- [ ] Gäller även i ren/ny databas (om möjligt)
+- [ ] Påverkar säkerhet/sekretess (beskriv om ja)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,42 @@
+---
+name: "Funktionsförslag"
+about: "Föreslå en förbättring eller ny funktion"
+title: "feat: "
+labels: ["enhancement"]
+assignees: []
+---
+
+## Problem / Bakgrund
+Vilket problem ska lösas? Varför är detta viktigt?
+
+## Mål
+Mätbara mål för förändringen (1–3 punkter).
+
+## Omfattning
+Vad ingår i denna förändring.
+
+## Icke-mål
+Vad ingår uttryckligen inte.
+
+## Förslag / Lösning
+Beskriv den föreslagna lösningen. Skisser, API-kontrakt, datamodell etc.
+
+## Alternativ
+Andra lösningar som övervägts och varför de avfärdats.
+
+## Påverkan
+- Databas/migration: Ja/Nej
+- API-ändringar: Ja/Nej
+- UI/UX: Ja/Nej (skärmdumpar/skisser)
+
+## Risker och rollback
+Kort riskbedömning och rollback-plan.
+
+## Acceptanskriterier
+- [ ] Kriterium 1
+- [ ] Kriterium 2
+
+## Checklista
+- [ ] Dokumentation uppdaterad
+- [ ] CHANGELOG uppdaterad
+- [ ] Testfall (manuella/automatiska) beskrivna

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,42 @@
+# PR-mall
+
+> Fyll i kort och sakligt. Ta bort irrelevanta sektioner.
+
+## Titel
+- Prefix: feat | fix | refactor | docs | chore | test
+- Kort beskrivning
+
+## Sammanfattning
+- Vad och varför i 1–3 punkter.
+
+## Ändringar
+- Lista de viktigaste ändringarna (API, modeller, vyer, mallar, jobb, skript).
+
+## Databas / Migrationer
+- [ ] Migration behövs
+  - Fil(er): `db/migrations/...`
+  - Idempotent: Ja/Nej
+  - Backfill: Ja/Nej — beskriv ev. körning och påverkan
+
+## Skärmdumpar (valfritt)
+- Före/Efter för UI-relaterat.
+
+## Testning
+- Manuella steg för verifiering (korta, punktlistor)
+- Resultat och kända begränsningar
+
+## Checklista
+- [ ] Bygger och startar lokalt utan fel
+- [ ] Lint/format OK (om tillämpligt)
+- [ ] Enheter/route-funktioner manuelltestade
+- [ ] DB-migrering körd i dev och verifierad
+- [ ] Backfill bedömd och/eller körd vid behov
+- [ ] Dokumentation/CHANGELOG uppdaterad
+- [ ] Säkerhet/sekretess beaktad (t.ex. PII i loggar, åtkomstkontroll)
+
+## Risker och rollback
+- Kort riskbedömning
+- Rollback-plan (t.ex. revert + nedgradring av schema om nödvändigt)
+
+## Relaterat
+- Closes #... | Relaterar till #... | Beroenden: ...

--- a/app/models.py
+++ b/app/models.py
@@ -18,6 +18,8 @@ class Transaction(db.Model):
     description = db.Column(db.String(255), nullable=True)
     amount = db.Column(db.Numeric(10, 2), nullable=False)
     transaction_type_id = db.Column(db.Integer, db.ForeignKey('TransactionTypes.id'), nullable=False)
+    # Bokföringsår (period): möjliggör att knyta transaktionen till ett annat år än datumets
+    period_year = db.Column(db.Integer, nullable=True)
     # Fria textfält (legacy) – behålls för bakåtkompatibilitet
     supplier = db.Column(db.String(255), nullable=True)
     member = db.Column(db.String(255), nullable=True)
@@ -82,6 +84,7 @@ class Apartment(db.Model):
 
 class ApartmentOwnership(db.Model):
     __tablename__ = 'ApartmentOwnerships'
+    __table_args__ = {'implicit_returning': False}
     id = db.Column(db.Integer, primary_key=True)
     apartment_id = db.Column(db.Integer, db.ForeignKey('Apartments.id'), nullable=False, index=True)
     member_id = db.Column(db.Integer, db.ForeignKey('Members.id'), nullable=False, index=True)

--- a/app/transactions/routes.py
+++ b/app/transactions/routes.py
@@ -9,7 +9,7 @@ from . import transactions
 from ..models import Transaction, TransactionType, Member, Supplier
 from ..extensions import db
 from datetime import datetime
-from sqlalchemy import asc, desc, and_, or_, func
+from sqlalchemy import asc, desc, and_, or_, func, extract
 from datetime import date, timedelta
 
 @transactions.route('/')
@@ -30,6 +30,9 @@ def list():
     tag_kind = request.args.get('tag_kind', 'all')  # all|member|supplier|none|any
     amount_min = request.args.get('amount_min', type=float)
     amount_max = request.args.get('amount_max', type=float)
+    # Nytt: filter för bokföringsår (period) och läge för årsfilter
+    period_year = request.args.get('period_year', type=int)
+    year_mode = request.args.get('year_mode', 'period')  # period|date
 
     # Bygg upp grundfrågan mot databasen
     query = Transaction.query
@@ -50,11 +53,23 @@ def list():
             start_date = last_month_end.replace(day=1)
             end_date = last_month_end
         elif preset == 'this_year':
-            start_date = today.replace(month=1, day=1)
-            end_date = today.replace(month=12, day=31)
+            # Om vi filtrerar på periodår, använd år likamed idag.year, annars datumintervall
+            if year_mode == 'period':
+                # markerar att vi inte sätter start/end-datum
+                start_date = None
+                end_date = None
+                period_year = period_year or today.year
+            else:
+                start_date = today.replace(month=1, day=1)
+                end_date = today.replace(month=12, day=31)
         elif preset == 'last_year':
-            start_date = today.replace(year=today.year-1, month=1, day=1)
-            end_date = today.replace(year=today.year-1, month=12, day=31)
+            if year_mode == 'period':
+                start_date = None
+                end_date = None
+                period_year = period_year or (today.year - 1)
+            else:
+                start_date = today.replace(year=today.year-1, month=1, day=1)
+                end_date = today.replace(year=today.year-1, month=12, day=31)
         elif preset == 'last_30':
             start_date = today - timedelta(days=30)
             end_date = today
@@ -80,6 +95,11 @@ def list():
         query = query.filter(Transaction.transaction_date >= start_date)
     if end_date:
         query = query.filter(Transaction.transaction_date <= end_date)
+
+    # Filtrera på bokföringsår om angivet eller om årspreset med period-läge
+    if period_year is not None:
+        year_expr = func.coalesce(Transaction.period_year, extract('year', Transaction.transaction_date))
+        query = query.filter(year_expr == period_year)
 
     # Textsökning (beskrivning)
     if q:
@@ -152,10 +172,11 @@ def list():
         import io
         output = io.StringIO()
         writer = csv.writer(output, delimiter=';')
-        writer.writerow(['Datum', 'Beskrivning', 'Typ', 'Belopp', 'Medlem', 'Leverantör'])
+        writer.writerow(['Datum', 'Bokföringsår', 'Beskrivning', 'Typ', 'Belopp', 'Medlem', 'Leverantör'])
         for tx in all_transactions:
             writer.writerow([
                 tx.transaction_date.strftime('%Y-%m-%d'),
+                (tx.period_year if tx.period_year is not None else tx.transaction_date.year),
                 tx.description or '',
                 tx.type.name if tx.type else '',
                 f"{tx.amount}",
@@ -187,7 +208,9 @@ def list():
         amount_max=amount_max,
         transaction_types=transaction_types,
         members=members,
-        suppliers=suppliers,
+    suppliers=suppliers,
+    period_year=period_year,
+    year_mode=year_mode,
     )
 
 
@@ -201,6 +224,7 @@ def add():
         type_id = request.form.get('transaction_type_id')
         member_id = request.form.get('member_id', type=int)
         supplier_id = request.form.get('supplier_id', type=int)
+        period_year_val = request.form.get('period_year', type=int)
 
         if not date_str or not amount or not type_id:
             flash('Datum, belopp och typ är obligatoriska fält.', 'danger')
@@ -211,11 +235,15 @@ def add():
             flash('Välj antingen Medlem eller Leverantör, inte båda.', 'danger')
             return redirect(url_for('transactions.add'))
 
+        tx_date = datetime.strptime(date_str, '%Y-%m-%d').date()
+        # Defaulta bokföringsår till valt värde eller transaktionsdatumets år
+        py = period_year_val if period_year_val is not None else tx_date.year
         new_transaction = Transaction(
-            transaction_date=datetime.strptime(date_str, '%Y-%m-%d').date(),
+            transaction_date=tx_date,
             description=description,
             amount=amount,
-            transaction_type_id=type_id
+            transaction_type_id=type_id,
+            period_year=py
         )
         if member_id:
             new_transaction.member_id = member_id
@@ -231,11 +259,14 @@ def add():
     transaction_types = TransactionType.query.order_by(TransactionType.name).all()
     members = Member.query.order_by(Member.name).all()
     suppliers = Supplier.query.order_by(Supplier.name).all()
-    return render_template('transactions/transaction_form.html',
-                           title='Lägg till Transaktion',
-                           transaction_types=transaction_types,
-                           members=members,
-                           suppliers=suppliers)
+    return render_template(
+        'transactions/transaction_form.html',
+        title='Lägg till Transaktion',
+        transaction_types=transaction_types,
+        members=members,
+        suppliers=suppliers,
+        default_period_year=date.today().year,
+    )
 
 
 @transactions.route('/edit/<int:id>', methods=['GET', 'POST'])
@@ -250,6 +281,7 @@ def edit(id):
         transaction_to_edit.transaction_type_id = request.form.get('transaction_type_id')
         member_id = request.form.get('member_id', type=int)
         supplier_id = request.form.get('supplier_id', type=int)
+        period_year_val = request.form.get('period_year', type=int)
 
         if member_id and supplier_id:
             flash('Välj antingen Medlem eller Leverantör, inte båda.', 'danger')
@@ -257,6 +289,7 @@ def edit(id):
 
         transaction_to_edit.member_id = member_id if member_id else None
         transaction_to_edit.supplier_id = supplier_id if supplier_id else None
+        transaction_to_edit.period_year = period_year_val if period_year_val is not None else transaction_to_edit.transaction_date.year
         
         db.session.commit()
         flash('Transaktionen har uppdaterats.', 'success')

--- a/templates/transactions/transaction_form.html
+++ b/templates/transactions/transaction_form.html
@@ -41,6 +41,15 @@
                 <p class="mt-2 text-xs text-gray-500">Använd minus (-) för utgifter, t.ex. -150.50.</p>
             </div>
 
+                <!-- Bokföringsår (period) -->
+                <div>
+                    <label for="period_year" class="block text-sm font-medium text-gray-700">Bokföringsår</label>
+                    <input type="number" name="period_year" id="period_year" min="2000" max="2100"
+                        value="{{ (transaction.period_year if transaction else default_period_year) or '' }}"
+                        class="mt-1 block w-full py-2 px-3 border border-gray-300 bg-white rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"/>
+                    <p class="mt-1 text-xs text-gray-500">Standard är transaktionens år om inget anges.</p>
+                </div>
+
             <!-- Transaktionstyp -->
             <div>
                 <label for="transaction_type_id" class="block text-sm font-medium text-gray-700">Typ</label>

--- a/templates/transactions/transaction_list.html
+++ b/templates/transactions/transaction_list.html
@@ -38,6 +38,17 @@
             </select>
         </div>
         <div>
+            <label class="block text-sm text-gray-700">Års-läge</label>
+            <select name="year_mode" class="mt-1 w-full border rounded p-2">
+                <option value="period" {% if year_mode=='period' %}selected{% endif %}>Bokföringsår</option>
+                <option value="date" {% if year_mode=='date' %}selected{% endif %}>Datumår</option>
+            </select>
+        </div>
+        <div>
+            <label class="block text-sm text-gray-700">Bokföringsår</label>
+            <input type="number" name="period_year" value="{{ period_year if period_year is not none else '' }}" class="mt-1 w-full border rounded p-2">
+        </div>
+        <div>
             <label class="block text-sm text-gray-700">Startdatum</label>
             <input type="date" name="start_date" value="{{ start_date }}" class="mt-1 w-full border rounded p-2" id="start_date">
         </div>
@@ -187,8 +198,9 @@
                 {% for tx in transactions %}
                 <tr class="border-b border-gray-200 hover:bg-gray-50">
                     <td class="py-3 px-4 text-sm text-gray-800">{{ tx.transaction_date.strftime('%Y-%m-%d') }}</td>
-                                        <td class="py-3 px-4 font-medium text-gray-900">
+                    <td class="py-3 px-4 font-medium text-gray-900">
                                                 {{ tx.description or 'Ingen beskrivning' }}
+                        <span class="ml-2 text-xs bg-gray-100 text-gray-800 px-2 py-0.5 rounded">År: {{ tx.period_year if tx.period_year is not none else tx.transaction_date.year }}</span>
                                                 {% if tx.member_ref %}
                                                     <span class="ml-2 text-xs bg-blue-100 text-blue-800 px-2 py-0.5 rounded">Medlem: {{ tx.member_ref.name }}</span>
                                                 {% elif tx.supplier_ref %}


### PR DESCRIPTION
Inför period_year på transaktioner för att styra bokföringsår oberoende av datumår.
All årslogik i listor, rapporter, prognos och dashboard baseras på bokföringsår via coalesce(period_year, year(transaction_date)).
Formulär, filter och CSV-export uppdaterade för period_year.